### PR TITLE
Path and DXF decimal format fixes

### DIFF
--- a/UnitTestProject1/UnitTests.cs
+++ b/UnitTestProject1/UnitTests.cs
@@ -11,7 +11,7 @@ namespace UnitTestProject1
     [TestClass]
     public class UnitTests
     {
-        PTAP2DXF fakeApp = new PTAP2DXF();
+        readonly PTAP2DXF fakeApp = new PTAP2DXF();
 
         /// <summary>
         /// TEST BannerText - that List<byte>() {0, 126, 9, 9, 9, 126, 0} == 'A'

--- a/UnitTestProject1/ptap2dxf.Tests.csproj
+++ b/UnitTestProject1/ptap2dxf.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ptap2dxf/DxfMaker.cs
+++ b/ptap2dxf/DxfMaker.cs
@@ -74,7 +74,7 @@ namespace JA.Planar
 		private void DXF_BuildBlockBody()
 		{
 			DXF_BlockBody = DXF_BlockBody + "BLOCK|  8|0|  2|*D" + BlockIndex + "|70|     1| 10|0.0| 20|0.0| 30|0.0|  3|*D" + BlockIndex + "|  1||0|ENDBLK|  8|0|0|";
-			BlockIndex = BlockIndex + 1;
+			BlockIndex++;
 		}
 
 		private string DXF_BlockFooter()
@@ -100,8 +100,8 @@ namespace JA.Planar
 
 		public bool DXF_Save(string fpath)
 		{
-			string strDXF_Output = null;
-			string[] varDXF = null;
+			string strDXF_Output;
+			string[] varDXF;
             try
             {
                 //Build a full text string
@@ -166,7 +166,7 @@ namespace JA.Planar
 			strDim[4] = " 13|" + x1 + "| 23|" + y1 + "| 33|0.0";
 			strDim[5] = " 14|" + x2 + "| 24|" + y2 + "| 34|0.0" + (iAng == 0 ? "" : "| 50|" + iAng);
 			strDim[6] = "1001|ACAD|1000|DSTYLE|1002|{|1070|   287|1070|     3|1070|    40|1040|" + DimScale + "|1070|   271|1070|     3|1070|   272|1070|     3|1070|   279|1070|     0|1002|}|  0|";
-			DXF_BodyText = DXF_BodyText + string.Join("|", strDim);
+			DXF_BodyText += string.Join("|", strDim);
 			//All dimensions need to be referenced in the header information
 			DXF_BuildBlockBody();
 		}
@@ -183,7 +183,7 @@ namespace JA.Planar
 			DXF_BodyText += string.Join("|", strRectangle);
 		}
 
-		private void DXF_Border(float x1, float y1, float Z1, float x2, float y2, float Z2)
+		public void DXF_Border(float x1, float y1, float Z1, float x2, float y2, float Z2)
 		{
 			string[] strBorder = new string[6];
 			strBorder[0] = "POLYLINE|  8|" + Layer + "| 40|1| 41|1| 66|1| 70|1|0";
@@ -197,9 +197,9 @@ namespace JA.Planar
 
 		public void DXF_ShowText(float x, float y, float eAng, float eRad, string eText)
 		{
-			float eX = 0;
-			float eY = 0;
-			float iRadians = 0;
+			float eX;
+			float eY;
+			float iRadians;
 			iRadians = (float)(Math.PI*eAng/180);
 			//Find the angle at which to draw the arrow head and leader
             eX = x - (float)(eRad * (Math.Cos(iRadians)));
@@ -243,7 +243,7 @@ namespace JA.Planar
 			int N = points.Length / 2;
 			string[] nodes = new string[N + 2];
 			nodes[0] = "POLYLINE| 8|" + Layer + "| 66| 1|0";
-			int i = 0;
+			int i;
 			for (i = 0; i <= N - 1; i++)
 				nodes[i + 1] = "VERTEX| 8|" + Layer + "| 10| " + points[2 * i] + "| 20| " + points[2 * i + 1] + "|0";
 			nodes[N + 1] = "SEQEND| 8|" + Layer + "|0|";
@@ -262,11 +262,11 @@ namespace JA.Planar
 
         public void DXF_Note(double x, double y, string note, double txt_height )
 		{
-			string[] lines = null;
+			string[] lines;
 			lines = note.Split(new string[] { Environment.NewLine } , StringSplitOptions.None);
 			for (int i = 0; i <= lines.Length - 1; i++) {
                 DXF_Text((float)x, (float)y, 0, (float)txt_height, lines[i]);
-				y = y - 2 * txt_height;
+				y -= 2 * txt_height;
 			}
 		}
 	}

--- a/ptap2dxf/ptap2dxf.cs
+++ b/ptap2dxf/ptap2dxf.cs
@@ -28,6 +28,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -803,6 +804,11 @@ namespace Ptap2DXF
             int length = -1;
             Numbering requestedNumbering = Numbering.CODE;  // Default is to number the console output lines for the code part only
             int errorLevel = 0;                     // Argument processing result and completion status. If > 0 something went horribly wrong
+
+            // Force the number decimal separator to dot, since the DXF-file format requires it.
+            CultureInfo customCulture = (CultureInfo)CultureInfo.CurrentCulture.Clone();
+            customCulture.NumberFormat.NumberDecimalSeparator = ".";
+            CultureInfo.CurrentCulture = customCulture;
 
             // If no input or args then show Help and quit
             if (!args.Any())

--- a/ptap2dxf/ptap2dxf.cs
+++ b/ptap2dxf/ptap2dxf.cs
@@ -611,7 +611,7 @@ namespace Ptap2DXF
                         Console.Write("           ");   // pad out the width of the line number
                     Console.WriteLine("+-" + new string('-', level) + "+");  // see https://stackoverflow.com/questions/411752/best-way-to-repeat-a-character-in-c-sharp#411762
                 }
-                currentRow = currentRow + rowsThisSegment;
+                currentRow += rowsThisSegment;
                 // Save output if segmentsPerDXF used
                 if (!dryRun)
                 {
@@ -840,7 +840,7 @@ namespace Ptap2DXF
                                 }
                             }
                         }
-                        catch (Exception e)
+                        catch (Exception)
                         {
                             Console.WriteLine("Bad banner finename specified. Use " + sep + "bannerfile=\"/path/to/bannerfile\"");
                             errorLevel = 1;
@@ -853,7 +853,7 @@ namespace Ptap2DXF
                             if (tokens.Count() > 1)
                                 banner = parameter.ToUpper().Split('=').Last(); // Take original parameter because leading or trailing spaces may have been included in banner text
                         }
-                        catch (Exception e)
+                        catch (Exception)
                         {
                             Console.WriteLine("Bad banner text string specified. Use " + sep + "bannertext=\"BANNERTEXT\"");
                             errorLevel = 1;
@@ -891,7 +891,7 @@ namespace Ptap2DXF
                             if (tokens.Count() > 1)
                                 interSegmentGap = int.Parse(tokens[1]);
                         }
-                        catch (Exception e)
+                        catch (Exception)
                         {
                             Console.WriteLine("Bad inter-segment gap value specified. Use a +ve integer to produce a seperation between tape segment long edges in 0.1 inch increments");
                             errorLevel = 1;
@@ -909,7 +909,7 @@ namespace Ptap2DXF
                             if (tokens.Count() > 1)
                                 inputFileName = tokens[1];
                         }
-                        catch (Exception e)
+                        catch (Exception)
                         {
                             Console.WriteLine("Bad input filename specified. Use " + sep + "input=\"/path/to/papertapeimagefile\"");
                             errorLevel = 1;
@@ -926,7 +926,7 @@ namespace Ptap2DXF
                             if (tokens.Count() > 1)
                                 leader = int.Parse(tokens[1]);
                         }
-                        catch (Exception e)
+                        catch (Exception)
                         {
                             Console.WriteLine("Bad tape leader padding value. Use a +ve integer to specify the number of 0.1-inch sprocket feed tape rows to prepend");
                             errorLevel = 1;
@@ -942,7 +942,7 @@ namespace Ptap2DXF
                             if (level < 1 || level > 8)
                                 throw new Exception();
                         }
-                        catch (Exception e)
+                        catch (Exception)
                         {
                             Console.WriteLine("Bad level value:" + level + ". Use a +ve integer between 1 and 8 signifying the data bit width. Default is 8 for byte 8-level. Use 5 for 5-level Baudot.");
                             errorLevel = 1;
@@ -963,7 +963,7 @@ namespace Ptap2DXF
                                     mark = markString[0];
                             }
                         }
-                        catch (Exception e)
+                        catch (Exception)
                         {
                             Console.WriteLine("Bad mark string specified. Use " + sep + "mark=\"O\". Only the first character is used.");
                             errorLevel = 1;
@@ -983,10 +983,10 @@ namespace Ptap2DXF
                                 string[] numberingTokens = tokens[1].Split(':');
                                 foreach (var numberingToken in numberingTokens)
                                     if (Enum.IsDefined(typeof(Numbering), numberingToken.ToUpper()))
-                                        requestedNumbering = requestedNumbering | (Numbering)Enum.Parse(typeof(Numbering), numberingToken, true);
+                                        requestedNumbering |= (Numbering)Enum.Parse(typeof(Numbering), numberingToken, true);
                             }
                         }
-                        catch (Exception e)
+                        catch (Exception)
                         {
                             Console.WriteLine("Bad line numbering specified. Use " + sep + "number={NONE, BANNER, LEADER, CODE, TRAILER, ALL}  CODE is the default");
                             errorLevel = 1;
@@ -999,8 +999,7 @@ namespace Ptap2DXF
                             if (tokens.Count() > 1)
                                 outputFileName = tokens[1];
                         }
-                        catch (Exception e)
-                        {
+                        catch (Exception)                        {
                             Console.WriteLine("Bad output filename specified. Use " + sep + "output=\"/path/to/outputDXFfile\"");
                             errorLevel = 1;
                         }
@@ -1013,15 +1012,15 @@ namespace Ptap2DXF
                             {
                                 string parityString = parameter.ToUpper().Split('=').Last();
                                 if (!string.IsNullOrEmpty(parityString))
-                                    switch (parityString.ToUpper())
+                                    parity = parityString.ToUpper() switch
                                     {
-                                        case "EVEN": parity = Parity.EVEN; break;
-                                        case "ODD": parity = Parity.ODD; break;
-                                        default: parity = Parity.NONE; break;
-                                    }
+                                        "EVEN" => Parity.EVEN,
+                                        "ODD" => Parity.ODD,
+                                        _ => Parity.NONE
+                                    };
                             }
                         }
-                        catch (Exception e)
+                        catch (Exception)
                         {
                             Console.WriteLine("Bad parity string specified. Use " + sep + "parity={NONE,EVEN,ODD} Default is NONE");
                             errorLevel = 1;
@@ -1045,12 +1044,12 @@ namespace Ptap2DXF
                                     if (tokens2[1].StartsWith("+-") || tokens2[1].StartsWith("-+")) // Take bytes from around specified offset (length -ve plus length +ve)
                                     {
                                         int halflength = int.Parse(tokens2[1].Remove(0, 2));
-                                        start = start - halflength; // Possible to have -ve start if producing joiner at or around zero (start of data)
+                                        start -= halflength; // Possible to have -ve start if producing joiner at or around zero (start of data)
                                         length = halflength * 2;
                                     }
                                     else if (tokens2[1].StartsWith("-"))    // Take bytes from specified offset going backwards (-ve length). Possible to have -ve start.
                                     {
-                                        start = start - length;
+                                        start -= length;
                                         length = Math.Abs(int.Parse(tokens2[1]));
                                     }
                                     else
@@ -1063,7 +1062,7 @@ namespace Ptap2DXF
                                 }
                             }
                         }
-                        catch (Exception e)
+                        catch (Exception)
                         {
                             Console.WriteLine("Bad range parameters. Use either --range=offset,length  or --range=offset,-length  or --range=offset,+-length");
                             errorLevel = 1;
@@ -1076,7 +1075,7 @@ namespace Ptap2DXF
                             if (tokens.Count() > 1)
                                 segment = int.Parse(tokens[1]);
                         }
-                        catch (Exception e)
+                        catch (Exception)
                         {
                             Console.WriteLine("Bad segment length specified. Use " + sep + "segment=length where length is a +ve integer");
                             errorLevel = 1;
@@ -1093,7 +1092,7 @@ namespace Ptap2DXF
                                     space = spaceString[0];
                             }
                         }
-                        catch (Exception e)
+                        catch (Exception)
                         {
                             Console.WriteLine("Bad space string specified. Use " + sep + "space=\" \". Only the first character is used.");
                             errorLevel = 1;
@@ -1109,7 +1108,7 @@ namespace Ptap2DXF
                             if (sprocketPos < 0 || sprocketPos > 8)
                                 throw new Exception();
                         }
-                        catch (Exception e)
+                        catch (Exception)
                         {
                             Console.WriteLine("Bad sprocket position value: " + sprocketPos + ". Use a +ve integer between 0 and (level + 1) signifying the position. Default for 8-level tape is 3, ie. between the 3rd and 4th data hole from the right.");
                             errorLevel = 1;
@@ -1122,7 +1121,7 @@ namespace Ptap2DXF
                             if (tokens.Count() > 1)
                                 messageText = parameter.Split('=').Last(); // Take original parameter because leading or trailing spaces may have been included in the input text
                         }
-                        catch (Exception e)
+                        catch (Exception)
                         {
                             Console.WriteLine("Bad input text string specified. Use " + sep + "text=\"THE QUICK BROWN FOX\"");
                             errorLevel = 1;
@@ -1135,7 +1134,7 @@ namespace Ptap2DXF
                             if (tokens.Count() > 1)
                                 trailer = int.Parse(tokens[1]);
                         }
-                        catch (Exception e)
+                        catch (Exception)
                         {
                             Console.WriteLine("Bad tape trailer addition value. Use a +ve integer to specify the number of 0.1-inch sprocket feed tape rows to append");
                             errorLevel = 1;
@@ -1165,7 +1164,7 @@ namespace Ptap2DXF
                             if (tokens.Count() > 1)
                                 segmentsPerDXF = int.Parse(tokens[1]);
                         }
-                        catch (Exception e)
+                        catch (Exception)
                         {
                             string label = "1-inch";
                             if (level == 5)
@@ -1475,16 +1474,16 @@ namespace Ptap2DXF
         // TODO FIX THIS BAUDOT CONVERSION. (It is only used for console formatting, not Baudot DXF generation)
         public static string ToBaudotName(this BitArray someBitArray)
         {
-            string s = string.Empty;
+            string s;
             byte z1 = someBitArray.ConvertToByte();
-
-            int bsr = z1  & 31;
-            char? csr = Baudot.GetLetter(bsr);
-
+            
+            //int bsr = z1  & 31;
+            //char? csr = Baudot.GetLetter(bsr);
+            
             int b = (int)z1 & 31;
             if (b == 27)
                 s = " SHIFT TO FIGS ";
-            if (b == 31)
+            else if (b == 31)
                 s = " SHIFT TO LETRS ";
             else
                 s = Convert.ToString(b);

--- a/ptap2dxf/ptap2dxf.cs
+++ b/ptap2dxf/ptap2dxf.cs
@@ -625,7 +625,10 @@ namespace Ptap2DXF
                                 outputName = someInputFileName;
                             string[] tokens = outputName.Split('.');
                             if (tokens.Count() > 1)
-                                outputName = tokens[0] + "_" + currentDXF.ToString("D4") + ".dxf";
+                            {
+                                tokens = tokens.SkipLast(1).ToArray(); // Remove extention
+                                outputName = String.Join(".", tokens) + "_" + currentDXF.ToString("D4") + ".dxf";
+                            }
                             dxf.DXF_Save(outputName);
                             dxf = new DxfMaker(); // Start a new DXF drawing
                             currentDXF++;
@@ -651,7 +654,10 @@ namespace Ptap2DXF
                     {
                         string[] tokens = someInputFileName.Split('.');
                         if (tokens.Count() > 1)
-                            outputName = tokens[0] + ".dxf";
+                        {
+                            tokens = tokens.SkipLast(1).ToArray(); // Remove extention
+                            outputName = String.Join(".", tokens) + ".dxf";
+                        }
                     }
                     return dxf.DXF_Save(outputName) ? 0 : 1;
                 }

--- a/ptap2dxf/ptap2dxf.csproj
+++ b/ptap2dxf/ptap2dxf.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Cleaned up the code to remove all warnings and code change suggestions (messages).
This also included upgrading to .NET Core 3.1, since .NET Core 2.2 has reached end of life, and is no longer supported.

Fixed a bug where the DXF-file ended up in the wrong folder.
It was because there was a dot in one of folder names in the path to the data file.

Also fixed a bug that will create invalid DXF-files if the users computer is configured to use another decimal symbol then dot (in Sweden we normally use comma as the decimal symbol).